### PR TITLE
Fixed null checking in isAgent function.

### DIFF
--- a/AgentDiscoveries-Frontend/app/src/components/utilities/user-helper.js
+++ b/AgentDiscoveries-Frontend/app/src/components/utilities/user-helper.js
@@ -35,7 +35,7 @@ export function isAdmin(){
 }
 
 export function isAgent() {
-    return window.localStorage.getItem('AgentId') !== null;
+    return window.localStorage.getItem('AgentId') !== 'null';
 }
 
 // Fire a 'login' event when the user info is updated.


### PR DESCRIPTION
window.localStorage stores null as 'null', so I've updated the isAgent function to check if AgentId doesn't equal 'null' instead of a literal null.